### PR TITLE
Add a constrain_crf option to the SequenceLabelingModel

### DIFF
--- a/adaseq/models/sequence_labeling_model.py
+++ b/adaseq/models/sequence_labeling_model.py
@@ -33,6 +33,8 @@ class SequenceLabelingModel(Model):
         dropout (float, `optional`): dropout rate, default `0.0`.
         word_dropout (bool): if `True`, use `WordDropout`.
         use_crf (bool, `optional`): whether to use crf, default `True`.
+        constrain_crf (bool, `optional`): If `True`, then crf is constrained at decoding time to produce valid sequences of tags,
+            requires use_crf to be `True`, default `False`.
         **kwargs: other arguments
     """
 


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #21 .

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->

- Adds an option called "constrain_crf" to the SequenceLabelingModel class, if use_crf and constrain_crf are both True then it substitutes the CRF module with the [CRFwithConstraints ](https://github.com/modelscope/AdaSeq/blob/6e1a9de4f692960af42d17b548d217d494c95465/adaseq/modules/decoders/crf.py#LL539C7-L539C25) module that implements constrains for BIO and BIOES valid tag decoding.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/modelscope/adaseq/blob/master/CONTRIBUTING.md#2-making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the [create a branch and work](https://github.com/modelscope/adaseq/blob/master/CONTRIBUTING.md#23-create-a-new-branch-to-work-on-your-fix-enhancement-or-model) section `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
